### PR TITLE
商品削除機能の実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -32,6 +32,11 @@ class ItemsController < ApplicationController
     end
   end
 
+  def destroy
+    item = Item.find(params[:id])
+    item.destroy
+  end
+
   def calculated
     price = params[:num].to_i
     num_fee = price / 10

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -33,8 +33,11 @@ class ItemsController < ApplicationController
   end
 
   def destroy
-    @item.destroy
-    redirect_to root_path
+    if @item.destroy
+      redirect_to root_path
+    else
+      render :show
+    end
   end
 
   def calculated

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,6 @@
 class ItemsController < ApplicationController
-  before_action :set_item, only: [:show, :edit, :update]
-  before_action :move_to_root, only: :edit
+  before_action :set_item, only: [:show, :edit, :update, :destroy]
+  before_action :move_to_root, only: [:edit, :destroy]
 
   def index
     @items = Item.includes(:order).order('created_at DESC')
@@ -33,8 +33,8 @@ class ItemsController < ApplicationController
   end
 
   def destroy
-    item = Item.find(params[:id])
-    item.destroy
+    @item.destroy
+    redirect_to root_path
   end
 
   def calculated

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -29,7 +29,7 @@
     <% if user_signed_in? && current_user.id == @item.user_id %>
     <%= link_to '商品の編集', edit_item_path(@item.id), method: :get, class: "item-red-btn" %>
     <p class='or-text'>or</p>
-    <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
+    <%= link_to '削除', item_path(@item.id), method: :delete, class:'item-destroy' %>
 
     <%# 商品が売れていない場合はこちらを表示しましょう %>
     <% elsif user_signed_in? && @order == nil %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: "items#index"
-  resources :items, only: [:index, :new, :create, :show, :edit, :update] do
+  resources :items do
     collection do
       get 'calculated'
     end


### PR DESCRIPTION
What: itemsコントローラーにdestroyアクションを定義、ビューファイルにdestroyアクションへのパスを記述
Why: 商品削除機能を実装するため

下記Gyazoのリンクです。ご確認のほどよろしくお願いいたします。
[トップページ商品一覧　削除前](https://gyazo.com/6c698cccba724d12c916f99e5de62ff3)
[削除アイテム詳細ページ１](https://gyazo.com/6fdcb08f1c9cb0374f77317e77a916e8)
[削除アイテム詳細ページ２](https://gyazo.com/684acb95b484945b9635016c04699d68)
[トップページ商品一覧　削除後](https://gyazo.com/5dded2befebca8fd733c649ad0b2ec0f)
[削除後のitemsテーブル](https://gyazo.com/75f985286b42f5fa54921a7c4d541319)